### PR TITLE
Revert breaking changes

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
@@ -4,9 +4,12 @@
 
 #include "HAL/PlatformSentryBreadcrumb.h"
 
-void USentryBreadcrumb::Initialize()
+USentryBreadcrumb::USentryBreadcrumb()
 {
-	NativeImpl = CreateSharedSentryBreadcrumb();
+	if (USentryBreadcrumb::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryBreadcrumb();
+	}
 }
 
 void USentryBreadcrumb::SetMessage(const FString &Message)

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -12,6 +12,20 @@ USentryEvent::USentryEvent()
 	}
 }
 
+USentryEvent* USentryEvent::CreateEventWithMessageAndLevel(const FString& Message, ESentryLevel Level)
+{
+	USentryEvent* Event = NewObject<USentryEvent>();
+
+	if(!Message.IsEmpty())
+	{
+		Event->SetMessage(Message);
+	}
+
+	Event->SetLevel(Level);
+
+	return Event;
+}
+
 void USentryEvent::SetMessage(const FString &Message)
 {
 	if (!NativeImpl)

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -4,9 +4,12 @@
 
 #include "HAL/PlatformSentryEvent.h"
 
-void USentryEvent::Initialize()
+USentryEvent::USentryEvent()
 {
-	NativeImpl = CreateSharedSentryEvent();
+	if (USentryEvent::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryEvent();
+	}
 }
 
 void USentryEvent::SetMessage(const FString &Message)

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -4,12 +4,9 @@
 
 #include "HAL/PlatformSentryEvent.h"
 
-void USentryEvent::Initialize(const FString& Message, ESentryLevel Level)
+void USentryEvent::Initialize()
 {
 	NativeImpl = CreateSharedSentryEvent();
-
-	SetMessage(Message);
-	SetLevel(Level);
 }
 
 void USentryEvent::SetMessage(const FString &Message)

--- a/plugin-dev/Source/Sentry/Private/SentryHint.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryHint.cpp
@@ -5,9 +5,12 @@
 #include "SentryAttachment.h"
 #include "HAL/PlatformSentryHint.h"
 
-void USentryHint::Initialize()
+USentryHint::USentryHint()
 {
-	NativeImpl = CreateSharedSentryHint();
+	if (USentryHint::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryHint();
+	}	
 }
 
 void USentryHint::AddAttachment(USentryAttachment* Attachment)

--- a/plugin-dev/Source/Sentry/Private/SentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryId.cpp
@@ -4,9 +4,12 @@
 
 #include "HAL/PlatformSentryId.h"
 
-void USentryId::Initialize()
+USentryId::USentryId()
 {
-	NativeImpl = CreateSharedSentryId();
+	if (USentryId::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryId();
+	}
 }
 
 FString USentryId::ToString() const

--- a/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
@@ -5,9 +5,12 @@
 
 #include "HAL/PlatformSentrySamplingContext.h"
 
-void USentrySamplingContext::Initialize()
+USentrySamplingContext::USentrySamplingContext()
 {
-	NativeImpl = CreateSharedSentrySamplingContext();
+	if (USentrySamplingContext::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentrySamplingContext();
+	}
 }
 
 USentryTransactionContext* USentrySamplingContext::GetTransactionContext() const

--- a/plugin-dev/Source/Sentry/Private/SentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryScope.cpp
@@ -6,9 +6,12 @@
 
 #include "HAL/PlatformSentryScope.h"
 
-void USentryScope::Initialize()
+USentryScope::USentryScope()
 {
-	NativeImpl = CreateSharedSentryScope();
+	if (USentryScope::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryScope();
+	}
 }
 
 void USentryScope::AddBreadcrumb(USentryBreadcrumb* Breadcrumb)

--- a/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
@@ -7,7 +7,7 @@
 
 #include "Interface/SentryTransactionInterface.h"
 
-USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const FString& Description)
+USentrySpan* USentryTransaction::StartChild(const FString& Operation, const FString& Description)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;
@@ -23,7 +23,7 @@ USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const 
 	}
 }
 
-USentrySpan* USentryTransaction::StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp)
+USentrySpan* USentryTransaction::StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;

--- a/plugin-dev/Source/Sentry/Private/SentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransactionContext.cpp
@@ -6,7 +6,10 @@
 
 void USentryTransactionContext::Initialize(const FString& Name, const FString& Operation)
 {
-	NativeImpl = CreateSharedSentryTransactionContext(Name, Operation);
+	if (USentryTransactionContext::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryTransactionContext(Name, Operation);
+	}
 }
 
 FString USentryTransactionContext::GetName() const

--- a/plugin-dev/Source/Sentry/Private/SentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUser.cpp
@@ -4,9 +4,12 @@
 
 #include "HAL/PlatformSentryUser.h"
 
-void USentryUser::Initialize()
+USentryUser::USentryUser()
 {
-	NativeImpl = CreateSharedSentryUser();
+	if (USentryUser::StaticClass()->GetDefaultObject() != this)
+	{
+		NativeImpl = CreateSharedSentryUser();
+	}	
 }
 
 void USentryUser::SetEmail(const FString& Email)

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -80,7 +80,7 @@ void SentrySubsystemSpec::Define()
 			TestNotNull("Transaction is non-null", transaction);
 			TestFalse("Transaction is not finished", transaction->IsFinished());
 
-			USentrySpan* span = transaction->StartChildSpan(TEXT("Automation span"), TEXT("Description text"));
+			USentrySpan* span = transaction->StartChild(TEXT("Automation span"), TEXT("Description text"));
 			TestNotNull("Span is non-null", span);
 			TestFalse("Span is not finished", span->IsFinished());
 

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -5,6 +5,7 @@
 #include "SentryDefines.h"
 #include "SentrySettings.h"
 
+#include "Windows/WindowsPlatformStackWalk.h"
 #include "Windows/Infrastructure/WindowsSentryConverters.h"
 
 void FWindowsSentrySubsystem::InitWithSettings(

--- a/plugin-dev/Source/Sentry/Public/SentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Public/SentryBreadcrumb.h
@@ -18,9 +18,7 @@ class SENTRY_API USentryBreadcrumb : public UObject, public TSentryImplWrapper<I
 	GENERATED_BODY()
 
 public:
-	/** Initializes the breadcrumb. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentryBreadcrumb();
 
 	/** Sets message of the breadcrumb. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -18,9 +18,7 @@ class SENTRY_API USentryEvent : public UObject, public TSentryImplWrapper<ISentr
 	GENERATED_BODY()
 
 public:
-	/** Initializes the event with the specified message and level. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentryEvent();
 
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -18,14 +18,9 @@ class SENTRY_API USentryEvent : public UObject, public TSentryImplWrapper<ISentr
 	GENERATED_BODY()
 
 public:
-	/**
-	 * Initializes the event with the specified message and level.
-	 * 
-	 * @param Message Message to be sent.
-	 * @param Level Level of the event.
-	 */
+	/** Initializes the event with the specified message and level. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize(const FString& Message, ESentryLevel Level);
+	void Initialize();
 
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -19,6 +19,15 @@ class SENTRY_API USentryEvent : public UObject, public TSentryImplWrapper<ISentr
 
 public:
 	USentryEvent();
+	
+	/**
+	 * Creates the event with specified message and level.
+	 *
+	 * @param Message Message to be sent.
+	 * @param Level Level of the event.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	static USentryEvent* CreateEventWithMessageAndLevel(const FString& Message, ESentryLevel Level);
 
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryHint.h
+++ b/plugin-dev/Source/Sentry/Public/SentryHint.h
@@ -18,9 +18,7 @@ class SENTRY_API USentryHint : public UObject, public TSentryImplWrapper<ISentry
 	GENERATED_BODY()
 
 public:
-	/** Initializes the hint. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentryHint();
 
 	/** Adds attachment to event hint. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryId.h
+++ b/plugin-dev/Source/Sentry/Public/SentryId.h
@@ -17,9 +17,7 @@ class SENTRY_API USentryId : public UObject, public TSentryImplWrapper<ISentryId
 	GENERATED_BODY()
 
 public:
-	/** Initializes the identifier. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentryId();
 
 	/** Gets string representation of the event ID. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
@@ -17,9 +17,7 @@ class SENTRY_API USentrySamplingContext : public UObject, public TSentryImplWrap
 	GENERATED_BODY()
 
 public:
-	/** Initializes the sampling context. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentrySamplingContext();
 
 	/** Gets transaction context used for sampling. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryScope.h
+++ b/plugin-dev/Source/Sentry/Public/SentryScope.h
@@ -20,9 +20,7 @@ class SENTRY_API USentryScope : public UObject, public TSentryImplWrapper<ISentr
 	GENERATED_BODY()
 
 public:
-	/** Initializes the scope. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	USentryScope();
 
 	/** Adds a breadcrumb to the current Scope. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -14,6 +14,9 @@ class USentrySpan;
 
 /**
  * Representation of an activity to measure or track.
+ *
+ * NOTE: USentryTransaction should not be constructed with NewObject<...>() etc., and should instead
+ *       only be created by calling methods like StartTransaction(...) on USentrySubsystem.
  */
 UCLASS(BlueprintType)
 class SENTRY_API USentryTransaction : public UObject, public TSentryImplWrapper<ISentryTransaction, USentryTransaction>

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -26,11 +26,11 @@ class SENTRY_API USentryTransaction : public UObject, public TSentryImplWrapper<
 public:
 	/** Starts a new child span. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChildSpan(const FString& Operation, const FString& Description);
+	USentrySpan* StartChild(const FString& Operation, const FString& Description);
 
 	/** Starts a new child span with timestamp. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp);
+	USentrySpan* StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp);
 
 	/** Finishes and sends a transaction to Sentry. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryUser.h
+++ b/plugin-dev/Source/Sentry/Public/SentryUser.h
@@ -17,8 +17,7 @@ class SENTRY_API USentryUser : public UObject, public TSentryImplWrapper<ISentry
 	GENERATED_BODY()
 
 public:
-	/** Initialize the user. */
-	void Initialize();
+	USentryUser();
 
 	/** Sets the email address of the user. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")


### PR DESCRIPTION
This PR reverts changes to the plugin's public API that were breaking its backward compatibility with older versions:
- Replaced `Initialize` methods with default constructors that handle native implementation object creation whenever possible. It allows us to avoid a situation when user creates Sentry object with `NewObject` and forgets to initialize it explicitly causing no-op for all its methods.
- Restored old names for child span creation methods in `USentryTransaction`
- Restored `CreateEventWithMessageAndLevel` for `USentryEvent`